### PR TITLE
[#30] Do not generate dependencies

### DIFF
--- a/src/protojure/plugin/ast.clj
+++ b/src/protojure/plugin/ast.clj
@@ -4,6 +4,42 @@
 
 (ns protojure.plugin.ast)
 
+(defn update-when
+  "Updates a value keyed by 'k' in an associative structure 'm' with 'f' when 'k' is not nil"
+  [m k f]
+  (let [v (get m k)]
+    (cond-> m
+      (some? v) (assoc k (f v)))))
+
+(defn find-src
+  [proto-files src]
+  (some (fn [desc]
+          (when (= src (:name desc))
+            desc)) proto-files))
+
+(defn src-2-pkg
+  [proto-files src]
+  (:package (find-src proto-files src)))
+
+(defn deps-2-pkg
+  "Find the proto-files map object with name `dep-name`, and return the package key value"
+  [proto-files dependencies]
+  (map (partial src-2-pkg proto-files) dependencies))
+
+(defn update-deps
+  "Walks each proto map replacing the dependency entries with their package key value.
+
+ In more detail, walks each proto map in the parsed CodeGeneratorRequest :proto-file key, and if the :dependency
+ key is present, transforms the string equivalent to the name :key, to the corresponding :package
+ value. E.g. for `[{:name foo.proto :package org.one.foo}, {:name bar.proto :package org.one.bar
+ :dependency [foo.proto]]', the output second element becomes `{:name bar.proto, :package
+ org.one.bar :dependency [org.one.foo]}`
+
+ Note that in the fn passed to some, proto-file is used to indicate a given element in proto-files,
+ whereas in the CodeGeneratorRequest, proto-file is the key given to the list of all parsed protos"
+  [proto-files]
+  (map #(update-when % :dependency (partial deps-2-pkg proto-files)) proto-files))
+
 (defn- concat-desc
   "partially concatenates two descriptors together"
   [acc {:keys [message-type enum-type dependency service]}]
@@ -22,7 +58,8 @@
   (reduce concat-desc (first desc) (rest desc)))
 
 (defn new [proto-files]
-  (->> (group-by :package proto-files)
+  (->> (update-deps proto-files)
+       (group-by :package)
        (reduce (fn [acc [pkg desc]] (assoc acc pkg (merge-desc desc))) {})))
 
 (defn get-namespace [ast]
@@ -40,3 +77,4 @@
 
 (defn list-packages [ast]
   (keys ast))
+

--- a/src/protojure/plugin/core.clj
+++ b/src/protojure/plugin/core.clj
@@ -7,7 +7,6 @@
             [clojure.math.combinatorics :refer [cartesian-product]]
             [protojure.plugin.ast :as ast]))
 
-(declare update-dependency-names)
 ;;-------------------------------------------------------------------
 ;; Entry point
 ;;
@@ -21,9 +20,9 @@
 ;; of the strings grpc-server,grpc-client in the `protoc --plugin`
 ;; string.
 ;;-------------------------------------------------------------------
-(defn generate [{:keys [proto-file parameter] :as config}]
-  (let [protos (ast/new (update-dependency-names proto-file))
-        pkgs (ast/list-packages protos)]
+(defn generate [{:keys [file-to-generate proto-file parameter] :as config}]
+  (let [protos (ast/new proto-file)
+        pkgs (ast/deps-2-pkg proto-file file-to-generate)]
     (validity-checks protos)
     (let [parameters (when parameter (-> parameter (clojure.string/split #",") set))
           server (contains? parameters "grpc-server")
@@ -34,32 +33,3 @@
           impls (->> (cartesian-product pkgs templates)
                      (mapcat (partial apply generate-impl protos)))]
       {:file impls})))
-
-(defn update-when
-  "Updates a value keyed by 'k' in an associative structure 'm' with 'f' when 'k' is not nil"
-  [m k f]
-  (let [v (get m k)]
-    (cond-> m
-      (some? v) (assoc k (f v)))))
-
-(defn xform-deps-names-to-deps-packages
-  "Find the proto-files map object with name `dep-name`, and return the package key value"
-  [proto-files dependencies]
-  (map (fn [dep-name]
-         (:package (some (fn [p-file]
-                           (when (= dep-name (:name p-file))
-                             p-file)) proto-files))) dependencies))
-
-(defn update-dependency-names
-  "Walks each proto map replacing the dependency entries with their package key value.
-
- In more detail, walks each proto map in the parsed CodeGeneratorRequest :proto-file key, and if the :dependency
- key is present, transforms the string equivalent to the name :key, to the corresponding :package
- value. E.g. for `[{:name foo.proto :package org.one.foo}, {:name bar.proto :package org.one.bar
- :dependency [foo.proto]]', the output second element becomes `{:name bar.proto, :package
- org.one.bar :dependency [org.one.foo]}`
-
- Note that in the fn passed to some, proto-file is used to indicate a given element in proto-files,
- whereas in the CodeGeneratorRequest, proto-file is the key given to the list of all parsed protos"
-  [proto-files]
-  (map #(update-when % :dependency (partial xform-deps-names-to-deps-packages proto-files)) proto-files))


### PR DESCRIPTION
This patch limits the output of the compiler based on the specific input files
listed in the AST.  We should not generate packages for .proto files that are
not in this list.

Fixes #30

Signed-off-by: Greg Haskins <greg@manetu.com>