### PR TITLE
Ensure pkg list is distinct

### DIFF
--- a/src/protojure/plugin/core.clj
+++ b/src/protojure/plugin/core.clj
@@ -22,7 +22,7 @@
 ;;-------------------------------------------------------------------
 (defn generate [{:keys [file-to-generate proto-file parameter] :as config}]
   (let [protos (ast/new proto-file)
-        pkgs (ast/deps-2-pkg proto-file file-to-generate)]
+        pkgs (distinct (ast/deps-2-pkg proto-file file-to-generate))]
     (validity-checks protos)
     (let [parameters (when parameter (-> parameter (clojure.string/split #",") set))
           server (contains? parameters "grpc-server")


### PR DESCRIPTION
An inadvertent bug was introduced with commit adc4b0f2.  This patch fixes it
by ensuring our package list is distinct.

Signed-off-by: Greg Haskins <greg@manetu.com>