### PR TITLE
Resolve potential OneOf naming collisions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 - Matt Rkiouak <mrkiouak@statestreet.com>
 - Jon Andrews <jandrews1@statestreet.com>
 - George Lindsell <glindsell@statestreet.com>
+- Sean Harrap <sean.harrap@gmail.com>

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [protojure "1.5.11"]
                  [protojure/google.protobuf "0.9.1"]
-                 [com.google.protobuf/protobuf-java "3.13.0"]
+                 [com.google.protobuf/protobuf-java "3.14.0"]
                  [org.antlr/ST4 "4.3.1"]
                  [slingshot "0.12.2"]
                  [camel-snake-kebab "0.4.2"]

--- a/resources/generators/interface.stg
+++ b/resources/generators/interface.stg
@@ -56,21 +56,21 @@ messages(generic_namespace, namespace, enums, messages, requires, rpcs, server, 
 <endif>
 >>
 
-emit_oneof_fields(name, ofields) ::=
+emit_oneof_fields(name, oparentname, ofields) ::=
 <<
 <if(ofields)>
 ;;----------------------------------------------------------------------------------
 ;;----------------------------------------------------------------------------------
-;; <name>'s oneof Implementations
+;; <oparentname>-<name>'s oneof Implementations
 ;;----------------------------------------------------------------------------------
 ;;----------------------------------------------------------------------------------
 
-(defn convert-<name> [origkeyval]
+(defn convert-<oparentname>-<name> [origkeyval]
   (cond
      <ofields.values:{of|<emit_replace_field(name, of)>}; separator="\n">
      :default origkeyval))
 
-(defn write-<name> [<name> os]
+(defn write-<oparentname>-<name> [<name> os]
   (let [field (first <name>)
         k (when-not (nil? field) (key field))
         v (when-not (nil? field) (val field))]
@@ -159,7 +159,7 @@ emit_default(desc)        ::= "<if(desc.type.repeated)>:<desc.name> [] <else><em
 emit_replace_field(name, of)          ::= "(get-in origkeyval [:<name> :<of.name>]) <if(of.isnested)>(update-in origkeyval [:<name> :<of.name>] <emit_type(of.type, \"new-\")>)<else>origkeyval<endif>"
 emit_oneof_reader_field(name, desc)   ::= "<desc.tag> [:<name> {:<desc.name> <if(desc.ismap)><reader_map_field(desc.type)><else><reader_field(desc.type)><endif>}]"
 process_reader_field(field)           ::= "<if(field.ofields)><field.ofields.values:{f|<emit_oneof_reader_field(field.name, f)><\n>}><elseif(!field.oindex)><emit_reader_field(field)><\n><endif>"
-emit_oneof(items)                     ::= "<items.values:{field|<emit_oneof_fields(field.name, field.ofields)>}>"
+emit_oneof(items)                     ::= "<items.values:{field|<emit_oneof_fields(field.name, field.oparentname, field.ofields)>}>"
 emit_specname(ns,desc,field)          ::= ":<ns>.<desc.name>/<field.name>"
 emit_maybe_specname(ns,desc,field)    ::= "<if(field.type.spec)><emit_specname(ns,desc,field)> <endif>"
 emit_maybe_repeatspec(ns,desc,field)  ::= "<if(field.type.repeated)>(s/every <endif><field.type.spec><if(field.type.repeated)>)<endif>"
@@ -217,7 +217,7 @@ emit_message(namespace, desc) ::=
   (-> (merge <desc.name>-defaults init)
       <desc.nested.values:{field|<emit_new_field(field)>}; separator="\n">
 <if(desc.ofields)>
-      <desc.ofields.values:{field|(convert-<field.name>)}; separator="\n">
+      <desc.ofields.values:{field|(convert-<desc.name>-<field.name>)}; separator="\n">
 <endif>
       (map-><emit_symbol(desc)>)))
 


### PR DESCRIPTION
Resolves #51 by prepending the message name to all methods generated to handle `oneof` fields, and updates the tests to reflect the new format. For instance,

```proto
message Foo {
  oneof bar { ... }
}
```

Will generate methods named `*-Foo-bar-*` rather than `*-bar-*`.

---

Also bumps `com.google.protobuf/protobuf-java` since leiningen wasn't happy with the old version for me.

RE the DCO, I wasn't sure whether you want a full DCO copied into each commit or just the one-line signoff similar to your commit messages elsewhere in this repo. Let me know if you'd like me to change it. Thanks!